### PR TITLE
New image architecture

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
 
 
       - name: set baseimagename
-        run: echo "baseImageName=gesinn/docker-mediawiki-base" >> $GITHUB_ENV
+        run: echo "baseImageName=gesinn/mediawiki-base" >> $GITHUB_ENV
 
       - name: generate tags for image
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,10 +35,11 @@ jobs:
       - name: Generate dockerfile
         run: |
           ./generate_dockerfile.sh ${{matrix.mediawiki_version}} ${{matrix.php_version}} ${{matrix.variant}}
-    
-      - name: Retrieve MediaWiki version into github environment, for later tagging of image
+
+      - name: Retrieve MediaWiki version
         run: |
-          echo "MEDIAWIKI_FULL_VERSION=$(cat ./Dockerfile | sed -n -e 's/^.*ENV MEDIAWIKI_VERSION //p')" >> $GITHUB_ENV
+          source ./helpers.sh
+          echo "MEDIAWIKI_FULL_VERSION=$(mediawiki_version ${{matrix.mediawiki_version}})" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,13 +62,13 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
 
-      - name: set baseimagename
-        run: echo "baseImageName=gesinn/mediawiki-base" >> $GITHUB_ENV
+      - name: set imageRepository
+        run: echo "imageRepository=gesinn/mediawiki-base" >> $GITHUB_ENV
 
       - name: generate tags for image
         run: |
           source ./helpers.sh
-          echo "TAGS=$(generate_tags ${{ env.baseImageName}} ${{env.MEDIAWIKI_FULL_VERSION}} ${{matrix.mediawiki_version}} ${{matrix.php_version}} ${{matrix.php_default}} ${{matrix.variant}})" >> $GITHUB_ENV
+          echo "TAGS=$(generate_tags ${{ env.imageRepository}} ${{env.MEDIAWIKI_FULL_VERSION}} ${{matrix.mediawiki_version}} ${{matrix.php_version}} ${{matrix.php_default}} ${{matrix.variant}})" >> $GITHUB_ENV
 
       - name: Build and push
         id: docker_build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,22 +74,35 @@ jobs:
           fi
           echo $TAGS
           echo "TAGS=$TAGS" >> $GITHUB_ENV
-
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v4
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
         with:
-          context: ./
-          file: ./Dockerfile
-          network: host
-          allow: network.host
-          build-args: |
-             CACHEBUST=${{ steps.date.outputs.date }}
-          builder: ${{ steps.buildx.outputs.name }}
-          push: true
-          tags: ${{ env.TAGS }}
-          cache-from: type=local,src=/tmp/.buildx-cache/${{ matrix.mediawiki_version }}/${{ matrix.variant }}
-          cache-to: type=local,dest=/tmp/.buildx-cache/${{ matrix.mediawiki_version }}/${{ matrix.variant }}
+          images: |
+            gesinn/docker-mediawiki-base
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern=${{ env.mediawiki_version}}
+            type=semver,pattern=${{ env.MEDIAWIKI_FULL_VERSION}}
 
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+
+      # - name: Build and push
+      #   id: docker_build
+      #   uses: docker/build-push-action@v4
+      #   with:
+      #     context: ./
+      #     file: ./Dockerfile
+      #     network: host
+      #     allow: network.host
+      #     build-args: |
+      #        CACHEBUST=${{ steps.date.outputs.date }}
+      #     builder: ${{ steps.buildx.outputs.name }}
+      #     push: true
+      #     tags: ${{ env.TAGS }}
+      #     cache-from: type=local,src=/tmp/.buildx-cache/${{ matrix.mediawiki_version }}/${{ matrix.variant }}
+      #     cache-to: type=local,dest=/tmp/.buildx-cache/${{ matrix.mediawiki_version }}/${{ matrix.variant }}
+
+      # - name: Image digest
+      #   run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,25 +41,25 @@ jobs:
           source ./helpers.sh
           echo "MEDIAWIKI_FULL_VERSION=$(mediawiki_version ${{matrix.mediawiki_version}})" >> $GITHUB_ENV
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver-opts: network=host
+      # - name: Set up Docker Buildx
+      #   id: buildx
+      #   uses: docker/setup-buildx-action@v2
+      #   with:
+      #     driver-opts: network=host
 
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache/${{ matrix.mediawiki_version }}/${{ matrix.variant }}
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+      # - name: Cache Docker layers
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: /tmp/.buildx-cache/${{ matrix.mediawiki_version }}/${{ matrix.variant }}
+      #     key: ${{ runner.os }}-buildx-${{ github.sha }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-buildx-
 
 
-      - uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      # - uses: docker/login-action@v2
+      #   with:
+      #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
 
       - name: set baseimagename
@@ -67,26 +67,13 @@ jobs:
 
       - name: generate tags for image
         run: |
-          if [[ ${{matrix.php_version}} == ${{matrix.php_default}}  ]]; then
-            TAGS="${{ env.baseImageName}}:${{ env.MEDIAWIKI_FULL_VERSION}},${{ env.baseImageName}}:${{ matrix.mediawiki_version}},${{ env.baseImageName}}:${{ env.MEDIAWIKI_FULL_VERSION}}-php${{ matrix.php_version}},${{ env.baseImageName}}:${{ matrix.mediawiki_version}}-php${{ matrix.php_version}}"
-          else
-            TAGS="${{ env.baseImageName}}:${{ env.MEDIAWIKI_FULL_VERSION}}-php${{ matrix.php_version}},${{ env.baseImageName}}:${{ matrix.mediawiki_version}}-php${{ matrix.php_version}}"
-          fi
-          echo $TAGS
-          echo "TAGS=$TAGS" >> $GITHUB_ENV
-      
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            gesinn/docker-mediawiki-base
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern=${{ env.mediawiki_version}}
-            type=semver,pattern=${{ env.MEDIAWIKI_FULL_VERSION}}
+          source ./helpers.sh
+          echo "TAGS=$(generate_tags ${{ env.baseImageName}} ${{env.MEDIAWIKI_FULL_VERSION}} ${{matrix.mediawiki_version}} ${{matrix.php_version}} ${{matrix.php_default}} ${{matrix.variant}})" >> $GITHUB_ENV
 
+
+
+      - name: set baseimagename
+        run: echo ${{ env.TAGS }}
 
       # - name: Build and push
       #   id: docker_build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
 
 
       - name: set baseimagename
-        run: echo "baseImageName=gesinn/docker-mediawiki-base-${{ matrix.variant }}" >> $GITHUB_ENV
+        run: echo "baseImageName=gesinn/docker-mediawiki-base" >> $GITHUB_ENV
 
       - name: generate tags for image
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,25 +41,25 @@ jobs:
           source ./helpers.sh
           echo "MEDIAWIKI_FULL_VERSION=$(mediawiki_version ${{matrix.mediawiki_version}})" >> $GITHUB_ENV
 
-      # - name: Set up Docker Buildx
-      #   id: buildx
-      #   uses: docker/setup-buildx-action@v2
-      #   with:
-      #     driver-opts: network=host
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: network=host
 
-      # - name: Cache Docker layers
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: /tmp/.buildx-cache/${{ matrix.mediawiki_version }}/${{ matrix.variant }}
-      #     key: ${{ runner.os }}-buildx-${{ github.sha }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-buildx-
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache/${{ matrix.mediawiki_version }}/${{ matrix.variant }}
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
 
-      # - uses: docker/login-action@v2
-      #   with:
-      #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
-      #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
 
       - name: set baseimagename
@@ -70,26 +70,21 @@ jobs:
           source ./helpers.sh
           echo "TAGS=$(generate_tags ${{ env.baseImageName}} ${{env.MEDIAWIKI_FULL_VERSION}} ${{matrix.mediawiki_version}} ${{matrix.php_version}} ${{matrix.php_default}} ${{matrix.variant}})" >> $GITHUB_ENV
 
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./Dockerfile
+          network: host
+          allow: network.host
+          build-args: |
+             CACHEBUST=${{ steps.date.outputs.date }}
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ env.TAGS }}
+          cache-from: type=local,src=/tmp/.buildx-cache/${{ matrix.mediawiki_version }}/php-${{matrix.php_version}}/${{ matrix.variant }}
+          cache-to: type=local,dest=/tmp/.buildx-cache/${{ matrix.mediawiki_version }}/php-${{matrix.php_version}}/${{ matrix.variant }}
 
-
-      - name: set baseimagename
-        run: echo ${{ env.TAGS }}
-
-      # - name: Build and push
-      #   id: docker_build
-      #   uses: docker/build-push-action@v4
-      #   with:
-      #     context: ./
-      #     file: ./Dockerfile
-      #     network: host
-      #     allow: network.host
-      #     build-args: |
-      #        CACHEBUST=${{ steps.date.outputs.date }}
-      #     builder: ${{ steps.buildx.outputs.name }}
-      #     push: true
-      #     tags: ${{ env.TAGS }}
-      #     cache-from: type=local,src=/tmp/.buildx-cache/${{ matrix.mediawiki_version }}/${{ matrix.variant }}
-      #     cache-to: type=local,dest=/tmp/.buildx-cache/${{ matrix.mediawiki_version }}/${{ matrix.variant }}
-
-      # - name: Image digest
-      #   run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/helpers.sh
+++ b/helpers.sh
@@ -11,6 +11,16 @@ function mediawiki_version() {
 		| tail -1
 }
 
+# function generate_tags { args : string baseImageName , string mediawikiFullVersion , string mediawikiVersion , string phpVersion , string phpDefault string variant } {
+# 	if [[ ${phpVersion} == ${phpDefault}  ]]; then
+# 		TAGS="${baseImageName}:${mediawikiFullVersion},${baseImageName}:${mediawikiVersion},${baseImageName}:${mediawikiFullVersion}-php${phpVersion},${baseImageName}:${mediawikiVersion}-php${phpVersion}"
+# 	else
+# 		TAGS="${baseImageName}:${mediawikiFullVersion}-php${phpVersion},${baseImageName}:${mediawikiVersion}-php${phpVersion}"
+# 	fi
+# 	echo "TAGS=$TAGS" >> $GITHUB_ENV
+# }
+
+
 declare -A variantExtras=(
 	[apache]='\n# Enable Short URLs\nRUN set -eux; \\\n\ta2enmod rewrite; \\\n\t{ \\\n\t\techo \"<Directory /var/www/html>\"; \\\n\t\techo \"  RewriteEngine On\"; \\\n\t\techo \"  RewriteCond %{REQUEST_FILENAME} !-f\"; \\\n\t\techo \"  RewriteCond %{REQUEST_FILENAME} !-d\"; \\\n\t\techo \"  RewriteRule ^ %{DOCUMENT_ROOT}/index.php [L]\"; \\\n\t\techo \"</Directory>\"; \\\n\t} > \"$APACHE_CONFDIR/conf-available/short-url.conf\"; \\\n\ta2enconf short-url\n\n# Enable AllowEncodedSlashes for VisualEditor\nRUN sed -i \"s/<\\/VirtualHost>/\\tAllowEncodedSlashes NoDecode\\n<\\/VirtualHost>/\" \"$APACHE_CONFDIR/sites-available/000-default.conf\"'
 	[fpm]=''

--- a/helpers.sh
+++ b/helpers.sh
@@ -12,7 +12,7 @@ function mediawiki_version() {
 }
 
 function generate_tags () {
-	local baseImageName=$1
+	local imageRepository=$1
 	local mediawikiFullVersion=$2
 	local mediawikiVersion=$3
 	local phpVersion=$4
@@ -20,21 +20,21 @@ function generate_tags () {
 	local variant=$6
 
 	if [[ ${phpVersion} == ${phpDefault}  ]]; then
-		TAGS="${baseImageName}:${mediawikiVersion}-${variant},"
-		TAGS+="${baseImageName}:${mediawikiFullVersion}-${variant},"
-		
+		TAGS="${imageRepository}:${mediawikiVersion}-${variant},"
+		TAGS+="${imageRepository}:${mediawikiFullVersion}-${variant},"
+
 		# main tags, eg. gesinn/docker-mediawiki-base:1.40
 		# are only generated for apache variant of image
 		if [[ ${variant} == "apache" ]];then
-			TAGS+="${baseImageName}:${mediawikiVersion},"
-			TAGS+="${baseImageName}:${mediawikiFullVersion},"
+			TAGS+="${imageRepository}:${mediawikiVersion},"
+			TAGS+="${imageRepository}:${mediawikiFullVersion},"
 		fi
 	fi
 
-	TAGS+="${baseImageName}:${mediawikiFullVersion}-php${phpVersion},"
-	TAGS+="${baseImageName}:${mediawikiFullVersion}-php${phpVersion}-${variant},"
-	TAGS+="${baseImageName}:${mediawikiVersion}-php${phpVersion},"
-	TAGS+="${baseImageName}:${mediawikiVersion}-php${phpVersion}-${variant}"
+	TAGS+="${imageRepository}:${mediawikiFullVersion}-php${phpVersion},"
+	TAGS+="${imageRepository}:${mediawikiFullVersion}-php${phpVersion}-${variant},"
+	TAGS+="${imageRepository}:${mediawikiVersion}-php${phpVersion},"
+	TAGS+="${imageRepository}:${mediawikiVersion}-php${phpVersion}-${variant}"
 
 	echo $TAGS
 }

--- a/helpers.sh
+++ b/helpers.sh
@@ -11,7 +11,14 @@ function mediawiki_version() {
 		| tail -1
 }
 
-function generate_tags { args : string baseImageName , string mediawikiFullVersion , string mediawikiVersion , string phpVersion , string phpDefault , string variant } {
+function generate_tags () {
+	local baseImageName=$1
+	local mediawikiFullVersion=$2
+	local mediawikiVersion=$3
+	local phpVersion=$4
+	local phpDefault=$5
+	local variant=$6
+	
 	if [[ ${phpVersion} == ${phpDefault}  ]]; then
 		TAGS="${baseImageName}:${mediawikiFullVersion},${baseImageName}:${mediawikiVersion},${baseImageName}:${mediawikiFullVersion}-php${phpVersion},${baseImageName}:${mediawikiVersion}-php${phpVersion}"
 	else

--- a/helpers.sh
+++ b/helpers.sh
@@ -20,11 +20,14 @@ function generate_tags () {
 	local variant=$6
 
 	if [[ ${phpVersion} == ${phpDefault}  ]]; then
-		TAGS="${baseImageName}:${mediawikiFullVersion}-${variant},"
-		TAGS+="${baseImageName}:${mediawikiVersion}-${variant},"
+		TAGS="${baseImageName}:${mediawikiVersion}-${variant},"
+		TAGS+="${baseImageName}:${mediawikiFullVersion}-${variant},"
+		
+		# main tags, eg. gesinn/docker-mediawiki-base:1.40
+		# are only generated for apache variant of image
 		if [[ ${variant} == "apache" ]];then
-			TAGS+="${baseImageName}:${mediawikiFullVersion},"
 			TAGS+="${baseImageName}:${mediawikiVersion},"
+			TAGS+="${baseImageName}:${mediawikiFullVersion},"
 		fi
 	fi
 

--- a/helpers.sh
+++ b/helpers.sh
@@ -18,12 +18,21 @@ function generate_tags () {
 	local phpVersion=$4
 	local phpDefault=$5
 	local variant=$6
-	
+
 	if [[ ${phpVersion} == ${phpDefault}  ]]; then
-		TAGS="${baseImageName}:${mediawikiFullVersion},${baseImageName}:${mediawikiVersion},${baseImageName}:${mediawikiFullVersion}-php${phpVersion},${baseImageName}:${mediawikiVersion}-php${phpVersion}"
-	else
-		TAGS="${baseImageName}:${mediawikiFullVersion}-php${phpVersion},${baseImageName}:${mediawikiVersion}-php${phpVersion}"
+		TAGS="${baseImageName}:${mediawikiFullVersion}-${variant},"
+		TAGS+="${baseImageName}:${mediawikiVersion}-${variant},"
+		if [[ ${variant} == "apache" ]];then
+			TAGS+="${baseImageName}:${mediawikiFullVersion},"
+			TAGS+="${baseImageName}:${mediawikiVersion},"
+		fi
 	fi
+
+	TAGS+="${baseImageName}:${mediawikiFullVersion}-php${phpVersion},"
+	TAGS+="${baseImageName}:${mediawikiFullVersion}-php${phpVersion}-${variant},"
+	TAGS+="${baseImageName}:${mediawikiVersion}-php${phpVersion},"
+	TAGS+="${baseImageName}:${mediawikiVersion}-php${phpVersion}-${variant}"
+
 	echo $TAGS
 }
 

--- a/helpers.sh
+++ b/helpers.sh
@@ -11,14 +11,14 @@ function mediawiki_version() {
 		| tail -1
 }
 
-# function generate_tags { args : string baseImageName , string mediawikiFullVersion , string mediawikiVersion , string phpVersion , string phpDefault string variant } {
-# 	if [[ ${phpVersion} == ${phpDefault}  ]]; then
-# 		TAGS="${baseImageName}:${mediawikiFullVersion},${baseImageName}:${mediawikiVersion},${baseImageName}:${mediawikiFullVersion}-php${phpVersion},${baseImageName}:${mediawikiVersion}-php${phpVersion}"
-# 	else
-# 		TAGS="${baseImageName}:${mediawikiFullVersion}-php${phpVersion},${baseImageName}:${mediawikiVersion}-php${phpVersion}"
-# 	fi
-# 	echo "TAGS=$TAGS" >> $GITHUB_ENV
-# }
+function generate_tags { args : string baseImageName , string mediawikiFullVersion , string mediawikiVersion , string phpVersion , string phpDefault , string variant } {
+	if [[ ${phpVersion} == ${phpDefault}  ]]; then
+		TAGS="${baseImageName}:${mediawikiFullVersion},${baseImageName}:${mediawikiVersion},${baseImageName}:${mediawikiFullVersion}-php${phpVersion},${baseImageName}:${mediawikiVersion}-php${phpVersion}"
+	else
+		TAGS="${baseImageName}:${mediawikiFullVersion}-php${phpVersion},${baseImageName}:${mediawikiVersion}-php${phpVersion}"
+	fi
+	echo $TAGS
+}
 
 
 declare -A variantExtras=(


### PR DESCRIPTION
This pushes now images to "gesinn/mediawiki-base" and also put's the variant (apache, php-fpm) into the tag.

small changes